### PR TITLE
added dlls to the exclude list that did not import on production.

### DIFF
--- a/src/EmailModule/EmailModule.Libraries.ps1
+++ b/src/EmailModule/EmailModule.Libraries.ps1
@@ -18,7 +18,11 @@ if ($PSEdition -eq 'Core') {
         'Microsoft.Extensions.Primitives.dll',
         'System.Diagnostics.DiagnosticSource.dll',
         'System.Text.Encodings.Web.dll',
-        'Microsoft.Extensions.WebEncoders.dll'
+        'Microsoft.Extensions.WebEncoders.dll',
+        'Microsoft.AspNetCore.Http.Abstractions.dll',
+        'Microsoft.AspNetCore.Http.Features.dll',
+        'Microsoft.Extensions.FileProviders.Abstractions.dll',
+        'Microsoft.Net.Http.Headers.dll'
     )
     Get-ChildItem -Path (Join-Path $PSScriptRoot 'lib/net472') -Filter *.dll |
     Where-Object  { $_.Name -notin $exclude } |


### PR DESCRIPTION
DLLs to be exclude that did not import on production.
Windows Server 2022 Version 21H2 (OS Build 20348.4297)
PSVersion 5.1.20348.4294

    Microsoft.Extensions.WebEncoders.dll
    Microsoft.AspNetCore.Http.Abstractions.dll
    Microsoft.AspNetCore.Http.Features.dll
    Microsoft.Extensions.FileProviders.Abstractions.dll
    Microsoft.Net.Http.Headers.dll


## Description

Suppressing DLLs that will not import into powershell, works with out them so adding them to the exclude list.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [ ] I built `EmailLibraryCore` and `EmailLibraryDesktop` locally where applicable.
- [x] I ran (or considered) integration tests locally where feasible.
- [ ] This PR is targeted to the `testing` branch for CI build and integration testing.
- [ ] `CHANGELOG.md` updated (required for user-visible changes or breaking changes).
- [ ] No secrets or credentials are included in this PR.
- [ ] I have requested at least one reviewer and assigned relevant issues.

## Public API / Assembly notes (if applicable)
If this PR changes public C# APIs or assembly versions, document the change, compatibility considerations, and any required consumer updates.

## How to test / reproduce
Provide steps to reproduce or verify the change locally, including any commands or sample inputs.

## Additional information
Any other information that reviewers should know.
